### PR TITLE
Add failing test for camel case with single-letter word "409AFairMarket" and adjust regex to fix splitting words

### DIFF
--- a/misspellings_lib/__init__.py
+++ b/misspellings_lib/__init__.py
@@ -16,7 +16,7 @@ import string
 __version__ = '1.0.5'
 
 
-_NORM_REGEX = re.compile(r'(?<=[a-z])(?=[A-Z])')
+_NORM_REGEX = re.compile(r'(?<=[a-z])?(?=[A-Z])')
 _WORD_REGEX = re.compile(r'[\s_0-9\W]+', flags=re.UNICODE)
 
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -74,6 +74,9 @@ class TestUtilityFunction:
     def test_split_words_with_numbers(self):
         assert ['upper', 'lower'] == split_words('upper2lower')
 
+    def test_split_words_with_camel_case_single_letter(self):
+        assert ['A', 'Fair', 'Market'] == split_words('AFairMarket')
+
     def test_split_words_with_camel_case(self):
         assert ['one', 'Two', 'Three'] == split_words('oneTwoThree')
         assert ['one', 'Two', 'Three', 'Four'] == split_words(


### PR DESCRIPTION
## Test fail before adjusting the regex
```
============================= test session starts ==============================
platform darwin -- Python 3.9.16, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/devth/carta/misspellings
collected 26 items

tests/test_class.py ............F...                                     [ 61%]
tests/test_cli.py ..........                                             [100%]

=================================== FAILURES ===================================
______ TestUtilityFunction.test_split_words_with_camel_case_single_letter ______

self = <tests.test_class.TestUtilityFunction object at 0x103d091f0>

    def test_split_words_with_camel_case_single_letter(self):
>       assert ['A', 'Fair', 'Market'] == split_words('AFairMarket')
E       AssertionError: assert ['A', 'Fair', 'Market'] == ['AFair', 'Market']
E         At index 0 diff: 'A' != 'AFair'
E         Left contains one more item: 'Market'
E         Use -v to get more diff

tests/test_class.py:78: AssertionError
=========================== short test summary info ============================
FAILED tests/test_class.py::TestUtilityFunction::test_split_words_with_camel_case_single_letter
========================= 1 failed, 25 passed in 0.40s =========================
```

## Test pass after adjusting the regex in 8705852

```
============================= test session starts ==============================
platform darwin -- Python 3.9.16, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/devth/carta/misspellings
collected 26 items

tests/test_class.py ................                                     [ 61%]
tests/test_cli.py ..........                                             [100%]

============================== 26 passed in 0.38s ==============================

```

